### PR TITLE
Fix: "Enable Mobile Responsive" toggle resets to on after notification update

### DIFF
--- a/nxdev/notificationx/components/WrapperWithLoader.tsx
+++ b/nxdev/notificationx/components/WrapperWithLoader.tsx
@@ -22,7 +22,9 @@ const WrapperWithLoader: React.FC<{ isLoading?: boolean, classes?: string, div?:
                     : (forcedDesktopValues.includes(nx_type)
                         ? 'for_desktop'
                         : (builderContext?.values?.themes_tab || 'for_desktop'));
-                builderContext.setFieldValue( "is_mobile_responsive", nx_type !== "custom");
+                if ( ! builderValues?.nx_id ) {
+                    builderContext.setFieldValue( "is_mobile_responsive", nx_type !== "custom" );
+                }
                 setTimeout(() => {
                      if ( nx_type !== 'notification_bar' ) {
                         builderContext.setFieldValue("themes_tab", themeTabValue);


### PR DESCRIPTION
## Summary

- "Enable Mobile Responsive" toggle in the NotificationX builder snaps back to **on** every time an existing notification is updated, even if the user had previously turned it off — so the saved preference is silently discarded on each save.
- Root cause is `nxdev/notificationx/components/WrapperWithLoader.tsx`: its `useEffect` keyed on `builderContext.values.type` calls `setFieldValue("is_mobile_responsive", nx_type !== "custom")` on every type change — including the initial hydration when an existing notification's saved `type` populates the form, which overwrites the saved toggle before the user even touches the form.
- This PR adds an `nx_id` guard so the override only runs when there is no existing record (i.e. a new notification being created). Existing entries keep whatever the user previously saved.

## Reproduction (before fix)

1. Create any NotificationX notification (e.g. WooCommerce Sales) and leave the "Enable Mobile Responsive" toggle **off** under Customize → Themes → Mobile.
2. Save the notification.
3. Reopen the same notification from the list and click **Update** without changing anything else.
4. Reopen it once more — the toggle is back to **on**, mobile responsive is silently re-enabled.

Verified locally on NotificationX 3.2.7. Video reproduction: https://d.pr/v/YkVmYO

## Fix

`nxdev/notificationx/components/WrapperWithLoader.tsx` only. **+3 / -1.** The `setFieldValue("is_mobile_responsive", …)` call inside the type-change effect is wrapped in an `nx_id` guard so it short-circuits on edit and only runs when creating a new notification.

```diff
- builderContext.setFieldValue( "is_mobile_responsive", nx_type !== "custom");
+ if ( ! builderValues?.nx_id ) {
+     builderContext.setFieldValue( "is_mobile_responsive", nx_type !== "custom" );
+ }
```

## Test plan

- Create a new notification of any non-`custom` type → "Enable Mobile Responsive" defaults to **on** (unchanged behavior).
- Create a new notification of type `custom` → toggle defaults to **off** (unchanged behavior).
- Open an existing notification with the toggle set to **off**, save without changes, reopen → toggle is still **off**. ✅ (was failing before)
- Open an existing notification with the toggle set to **on**, save, reopen → toggle is still **on**.
- Change the type of an existing notification → toggle retains the user's saved value rather than snapping back to the type-based default.
- Other tabs/fields on the builder are unaffected; `themes_tab` still switches correctly when the type changes.

## Build artifacts

This PR touches only the webpack source. The compiled `assets/admin/js/admin.js` is intentionally not committed — it should be regenerated by the standard build pipeline before release.

## Reported by

Client-reported bug via Fluent Boards — [#81297 Bug Fix: NotificationX mobile responsive setting automatically re-enables after notification update](https://projects.startise.com/wp-admin/admin.php?page=fluent-boards#/boards/19/tasks/81297-bug-fix-notificationx-mobile-responsive-setting-automatically-re-enables-after-notification-update).
