### PR TITLE
Integrate Customer Reviews for WooCommerce anonymity: show "Anonymous" in review notifications

### DIFF
--- a/includes/Extensions/WooCommerce/WOOReviews.php
+++ b/includes/Extensions/WooCommerce/WOOReviews.php
@@ -486,7 +486,62 @@ class WooReviews extends Extension {
             }
         }
         $comment_data['email'] = get_comment_author_email($comment->comment_ID);
+
+        /**
+         * Respect anonymity chosen via the "Customer Reviews for WooCommerce" (CusRev) plugin.
+         *
+         * When a customer picks "Anonymous" on CusRev's review form, CusRev stores the review
+         * with comment_author set to its localized "Anonymous" label while still attaching the
+         * verified buyer's WordPress user id (and email) to the comment. NotificationX would
+         * otherwise take the user-id branch above and fall back to the account display name
+         * (often the email prefix, e.g. "X123" for X123@gmail.com) — leaking the very identity
+         * the customer asked to hide. The retained email would also resolve to their gravatar.
+         *
+         * When the review is anonymous we surface a neutral "Anonymous" label and drop the email
+         * so no identifying data (name, email prefix or gravatar) is exposed in the notification.
+         */
+        if ($this->is_anonymous_review($comment)) {
+            $anonymous_label = apply_filters('nx_woo_review_anonymous_label', __('Anonymous', 'notificationx'), $comment);
+            $comment_data['username']     = $anonymous_label;
+            $comment_data['name']         = $anonymous_label;
+            $comment_data['first_name']   = $anonymous_label;
+            $comment_data['last_name']    = '';
+            $comment_data['email']        = '';
+            $comment_data['is_anonymous'] = true;
+            unset($comment_data['user_id']);
+        }
+
         return $comment_data;
+    }
+
+    /**
+     * Determine whether a WooCommerce review was submitted anonymously.
+     *
+     * Anonymity is detected from the way "Customer Reviews for WooCommerce" (CusRev) stores
+     * the review:
+     *  - a comment_author equal to CusRev's "Anonymous" label, when CusRev is active. This is
+     *    the real-world case: CusRev persists the literal label (localized) as the author, so
+     *    we compare against both the localized string and the English fallback; or
+     *  - an empty comment_author (covers guest reviews left without a name and imported reviews
+     *    that CusRev's own Google feed treats as anonymous).
+     *
+     * The result is filterable so other review sources can opt into the same behaviour.
+     *
+     * @param \WP_Comment $comment
+     * @return bool
+     */
+    public function is_anonymous_review($comment) {
+        $author       = isset($comment->comment_author) ? trim((string) $comment->comment_author) : '';
+        $is_anonymous = ($author === '');
+
+        if (!$is_anonymous && (class_exists('Ivole') || class_exists('CR_Reviews'))) {
+            $cr_label = __('Anonymous', 'customer-reviews-woocommerce');
+            if (strcasecmp($author, $cr_label) === 0 || strcasecmp($author, 'Anonymous') === 0) {
+                $is_anonymous = true;
+            }
+        }
+
+        return (bool) apply_filters('nx_is_anonymous_review', $is_anonymous, $comment);
     }
 
     public function doc() {


### PR DESCRIPTION
## Summary

Integrates NotificationX with the **Customer Reviews for WooCommerce** (CusRev) plugin's anonymity feature. When a customer submits a product review anonymously, the social-proof notification now shows **"Anonymous"** instead of leaking the account display name / email prefix (e.g. "X123" for `X123@gmail.com`).

## The problem

When a customer picks **Anonymous** as their Display name on CusRev's review (reminder/aggregated) form, CusRev stores the review with `comment_author = "Anonymous"` while the verified buyer's WordPress `user_id` **and** email stay attached to the comment.

`WooReviews::add()` checked `user_id` first and used the account `display_name` (often the email prefix), ignoring the `comment_author`. So the notification displayed the customer's identity — exactly what they asked to hide. The retained email also resolved to their gravatar.

## The fix

In `includes/Extensions/WooCommerce/WOOReviews.php`, after building the review data, detect anonymous reviews and surface a neutral label:

- **Anonymous when:** `comment_author` equals CusRev's "Anonymous" label (localized string **or** English fallback) while CusRev is active (`Ivole`/`CR_Reviews`), **or** `comment_author` is empty (guest reviews / imports — matches CusRev's own Google-feed heuristic).
- **On anonymous:** set username/name to "Anonymous", blank the email (so no name, email prefix **or** gravatar leaks), flag `is_anonymous`.
- Normal reviews are untouched.
- Filterable: `nx_woo_review_anonymous_label`, `nx_is_anonymous_review`.

## Testing

Verified end-to-end in a WordPress + WooCommerce 10.9.1 + Customer Reviews for WooCommerce 5.113.0 sandbox:

- Reproduced a **real** anonymous review through CusRev's own storage path (`CR_Endpoint::create_review`) → stored as `comment_author="Anonymous"`, `user_id` set, email retained.
- Live NotificationX popup now renders **"Anonymous just reviewed …"** with the default avatar (no gravatar leak).
- Controls (logged-in named review, guest named review) still display the real name.

No behavior change for non-CusRev or non-anonymous reviews.
