### PR TITLE
Fix: Growth Alert (Inline) N+1 database queries on WooCommerce shop/archive pages

### DIFF
--- a/includes/Features/Inline.php
+++ b/includes/Features/Inline.php
@@ -24,6 +24,15 @@ class Inline {
     public $notifications_data = [];
 
     /**
+     * Request-level cache of notifications data, keyed by source.
+     * Inline hooks fire once per product in shop/archive loops; the
+     * result only varies by $source, so compute it once per request.
+     *
+     * @var array
+     */
+    protected $notifications_cache = [];
+
+    /**
      * __construct__ is for revoke first time to get ready
      *
      * @return void
@@ -35,33 +44,37 @@ class Inline {
 
 
     public function get_notifications_data( $source, $id = null, $settings = [] ) {
-        
+
         $exit = apply_filters('nx_inline_notifications_data', null, $source, $id, $settings);
         if($exit){
             return $exit;
         }
 
-        // if ( empty( $this->notifications_data ) ) {
-            $this->notifications_data = array( 'shortcode' => array() );
-            $notifications            = PostType::get_instance()->get_posts(
+        if ( ! isset( $this->notifications_cache[ $source ] ) ) {
+            $data          = array( 'shortcode' => array() );
+            $notifications = PostType::get_instance()->get_posts(
                 array(
                     'source'    => $source,
                     'enabled'   => true,
                     'is_inline' => true,
                 )
             );
-           
+
             do_action( 'nx_inline' );
 
             if ( ! empty( $notifications ) ) {
-                $this->notifications_data = FrontEnd::get_instance()->get_notifications_data(
+                $data = FrontEnd::get_instance()->get_notifications_data(
                     array(
                         'shortcode'        => array_column( $notifications, 'nx_id' ),
                         'inline_shortcode' => true,
                     )
                 );
             }
-        // }
+
+            $this->notifications_cache[ $source ] = $data;
+        }
+
+        $this->notifications_data = $this->notifications_cache[ $source ];
         return $this->notifications_data;
     }
 


### PR DESCRIPTION
## Problem

Growth Alert (inline) registers its render callback on `woocommerce_after_shop_loop_item` and `woocommerce_after_shop_loop_item_title`, which fire **once per product** in shop/archive loops. Every callback run called `Inline::get_notifications_data()`, whose request-level cache was commented out — so the same product-independent data was re-queried from the database for every product on the page (classic N+1). Reported by a client whose shop pages slowed down, with `NotificationX\Core\Database->get_posts` dominating Query Monitor.

This affects every site running NotificationX Pro with the WooCommerce module enabled — the queries fire even with **zero** Growth Alert campaigns created.

## Fix

Restore request-level memoization in `Inline::get_notifications_data()` (`includes/Features/Inline.php`), keyed by `$source` so different inline sources cannot receive each other's cached data (the likely reason the previous un-keyed cache was disabled). The computed result only varies by `$source` — `$id`/`$settings` are only passed to the `nx_inline_notifications_data` short-circuit filter — so per-request caching is safe. Per-product filtering still happens afterward in the extension render loop.

The old public `$notifications_data` property keeps its previous shape/behavior for backward compatibility.

## Verification (Docker sandbox, WP + WooCommerce 10.9.1, NX 3.2.10 + Pro 3.1.2, 11 products, one active Growth Alert stock campaign)

| | `Database->get_posts` total | from shop-loop callback |
|---|---|---|
| Before | 137 | 132 |
| After | **11** | **6** |

Rendered Growth Alert markup is byte-identical before/after (verified by diffing the archive page HTML). With no inline campaign, per-page calls drop from 49 to 7.

## Card

https://projects.startise.com/wp-admin/admin.php?page=fluent-boards#/boards/19/tasks/83239-Bug-Fix-%7C-Growth-Alert-(Inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)