### PR TITLE
fix(woocommerce): stop dropping Tutor LMS course orders from sales notifications

### DIFF
--- a/includes/Extensions/WooCommerce/WooCommerce.php
+++ b/includes/Extensions/WooCommerce/WooCommerce.php
@@ -218,7 +218,6 @@ class WooCommerce extends Extension {
     }
 
     public function status_transition($id, $from, $to, $order) {
-        $has_course = false;
         $from       = "wc-$from";
         $to         = "wc-$to";
         $items      = $order->get_items();
@@ -235,10 +234,7 @@ class WooCommerce extends Extension {
 
                 foreach ($items as $item) {
                     $key      = $id . '-' . $item->get_id();
-                    if (function_exists('tutor_utils')) {
-                        $has_course = tutor_utils()->product_belongs_with_course($item->get_product_id());
-                    }
-                    if ($has_course) {
+                    if ($this->is_excluded_course_item($item, $order)) {
                         continue;
                     }
 
@@ -271,8 +267,7 @@ class WooCommerce extends Extension {
         $order = wc_get_order($order_id);
         $items = $order->get_items();
         foreach( $items as $item ) {
-            $tutor_product = metadata_exists('post', $item->get_product_id(), "_tutor_product");
-            if($tutor_product ) {
+            if ($this->is_excluded_course_item($item, $order)) {
                 continue;
             }
             $order_item = $this->ordered_product($item->get_id(), $item, $order);
@@ -284,6 +279,41 @@ class WooCommerce extends Extension {
                 ], false);
             }
         }
+    }
+
+    /**
+     * Determine whether a Tutor LMS course-linked order item should be excluded
+     * from WooCommerce sales notifications.
+     *
+     * These items used to be dropped unconditionally, which silently hid every
+     * order for a course-linked product on stores that sell courses through
+     * WooCommerce. Exclusion is now opt-in and OFF by default. Re-enable it with:
+     *
+     *     add_filter('nx_woocommerce_exclude_tutor_course_products', '__return_true');
+     *
+     * Both Tutor detectors used across this class are honoured so the behaviour
+     * is consistent everywhere: product_belongs_with_course() and the
+     * _tutor_product product meta.
+     *
+     * @param \WC_Order_Item_Product $item  The order line item.
+     * @param mixed                  $order The order (WC_Order or order id) for filter context.
+     * @return bool True when the item should be skipped.
+     */
+    protected function is_excluded_course_item($item, $order = null) {
+        $exclude = apply_filters('nx_woocommerce_exclude_tutor_course_products', false, $item, $order);
+        if (!$exclude) {
+            return false;
+        }
+        if (!$item instanceof \WC_Order_Item_Product) {
+            return false;
+        }
+        $product_id = $item->get_product_id();
+        if (empty($product_id)) {
+            return false;
+        }
+        $belongs_to_course = function_exists('tutor_utils') && tutor_utils()->product_belongs_with_course($product_id);
+        $is_tutor_product  = metadata_exists('post', $product_id, '_tutor_product');
+        return $belongs_to_course || $is_tutor_product;
     }
 
     /**
@@ -302,11 +332,7 @@ class WooCommerce extends Extension {
         if( empty( $product ) ) {
             return false;
         }
-        $if_has_course = false;
-        if (function_exists('tutor_utils')) {
-            $if_has_course = tutor_utils()->product_belongs_with_course($item->get_product_id());
-        }
-        if ($if_has_course) {
+        if ($this->is_excluded_course_item($item, $order_id)) {
             return false;
         }
         $new_order = [];
@@ -439,11 +465,13 @@ class WooCommerce extends Extension {
         foreach ($wc_orders as $order) {
             $items = $order->get_items();
             foreach ($items as $item) {
-                $tutor_product = metadata_exists('post', $item->get_product_id(), "_tutor_product");
-                if ($tutor_product) {
+                if ($this->is_excluded_course_item($item, $order)) {
                     continue;
                 }
-                $orders[$order->get_id() . '-' . $item->get_id()] = $this->ordered_product($item->get_id(), $item, $order);
+                $entry = $this->ordered_product($item->get_id(), $item, $order);
+                if (!empty($entry) && is_array($entry)) {
+                    $orders[$order->get_id() . '-' . $item->get_id()] = $entry;
+                }
             }
         }
         return $orders;
@@ -458,7 +486,7 @@ class WooCommerce extends Extension {
      */
     public function check_order_status($return, $entry, $settings){
         $done     = !empty($settings['order_status']) ? $settings['order_status'] : ['wc-completed', 'wc-processing'];
-        if(!in_array($entry['data']['status'], $done)){
+        if (empty($entry['data']) || !is_array($entry['data']) || !in_array($entry['data']['status'] ?? '', $done, true)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

WooCommerce **Sales** notifications silently discard **every order whose product is linked to a Tutor LMS course**. On stores that sell courses through WooCommerce, no course orders ever appear and newly placed orders are never imported — the feature is effectively non-functional. A secondary defect stores the discarded orders as corrupt `data => false` entries, producing repeated PHP 8 `Trying to access array offset on false` warnings on the frontend.

Reproducible regardless of HPOS vs. legacy order storage. Observed on NotificationX 3.2.10 / Pro 3.1.4.

## Root cause

### Defect 1 — hardcoded course exclusion (primary)
Course-linked items were rejected unconditionally in **four** places, using **two different detectors**:

| Site | Detector | Action |
|---|---|---|
| `ordered_product()` | `product_belongs_with_course()` | `return false` |
| `status_transition()` | `product_belongs_with_course()` | `continue` |
| `manual_order()` | `_tutor_product` post meta | `continue` |
| `get_orders()` | `_tutor_product` post meta | `continue` |

Both the live import path (`status_transition()`) and the bulk rebuild path (`get_orders()`) applied a filter, which is why new orders were never imported and regeneration didn't help. There was no setting or filter guarding this behavior.

### Defect 2 — invalid entries stored, not skipped (secondary)
`get_orders()` pushed `ordered_product()`'s return value **unconditionally**. Because `get_orders()` pre-filters by `_tutor_product` meta while `ordered_product()` rejects by `product_belongs_with_course()`, any product that belongs to a course *without* `_tutor_product` meta slipped past the `get_orders()` guard, returned `false` from `ordered_product()`, and that `false` was persisted by `get_notification_ready()` as `'data' => false`. On the frontend, `check_order_status()` then evaluated `false['status']` → PHP 8 warning and a hidden entry.

## What changed (single file: `includes/Extensions/WooCommerce/WooCommerce.php`)

**Fix A — gate the exclusion behind an off-by-default filter, at all four sites.**
Introduced one helper, `is_excluded_course_item()`, that unifies both Tutor detectors and is gated behind a new filter:

```php
add_filter( 'nx_woocommerce_exclude_tutor_course_products', '__return_true' ); // opt back into the old behavior
```

Default (`false`) imports course orders as expected. All four call sites now route through this helper, so free **and** Pro behave consistently (Pro's `WooCommerce` extends this class and overrides none of these methods — verified — so no Pro change is needed).

**Fix B — never store invalid entries; harden the reader.**
- `get_orders()` now only stores non-empty array entries (skips every `false` branch of `ordered_product()`, not just the course one).
- `check_order_status()` guards against a missing/non-array `data` before reading `['status']`, eliminating the line-461 warning for all `false`-return branches.

## Backward compatibility
- Behavioral change is intentional and matches user expectation: course orders now appear. Stores that genuinely want them hidden can restore the old behavior with the new filter above.
- No schema/DB migration.

## Verification
- `php -l` clean on the changed file.
- The two changed method bodies were extracted verbatim and driven under PHP 8.2 with a strict error handler (any notice/warning = failure). **All 10 checks pass**, including: course product **imported** at the default filter; opt-in exclusion works via *both* detectors; and `data => false` returns `false` with **no** `array offset on false` warning.

> Note: the repo's PHPUnit suite is a full WordPress integration suite (`bin/install-wp-tests.sh` + WooCommerce + Tutor LMS) and could not be exercised in the authoring sandbox. Suggested regression tests to add there are listed below.

## Post-deploy migration (runtime, not code)
Existing datasets already contain corrupt `data => false` entries. After deploying: **regenerate** each affected WooCommerce/Sales notification (rebuilds from live orders), then clear page/server cache. No DB migration required.

## Suggested regression tests (WP integration suite)
- Order with a course-linked product on a Sales notification → entry **imported** (filter default `false`).
- With `nx_woocommerce_exclude_tutor_course_products` → `true` → course entry **excluded**.
- Order with a deleted/invalid product → **skipped**, not stored as `false`, no PHP warning on render.
- Mixed order (course + non-course) → non-course item still imports.
- Newly placed order via `status_transition()` (Processing/Completed) → imported consistently with regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
